### PR TITLE
Add codelayer and codelayer-nightly CLI aliases

### DIFF
--- a/Casks/codelayer-nightly.rb
+++ b/Casks/codelayer-nightly.rb
@@ -14,6 +14,7 @@ cask "codelayer-nightly" do
   app "CodeLayer-Nightly.app"
 
   binary "#{appdir}/CodeLayer-Nightly.app/Contents/Resources/bin/humanlayer", target: "humanlayer-nightly"
+  binary "#{appdir}/CodeLayer-Nightly.app/Contents/Resources/bin/humanlayer", target: "codelayer-nightly"
   binary "#{appdir}/CodeLayer-Nightly.app/Contents/Resources/bin/hld", target: "hld-nightly"
 
   zap trash: [

--- a/Casks/codelayer.rb
+++ b/Casks/codelayer.rb
@@ -19,6 +19,7 @@ cask "codelayer" do
   app "CodeLayer.app"
 
   binary "#{appdir}/CodeLayer.app/Contents/Resources/bin/humanlayer"
+  binary "#{appdir}/CodeLayer.app/Contents/Resources/bin/humanlayer", target: "codelayer"
   binary "#{appdir}/CodeLayer.app/Contents/Resources/bin/hld"
 
   zap trash: [


### PR DESCRIPTION
Add binary symlinks for 'codelayer' and 'codelayer-nightly' commands alongside the existing 'humanlayer' commands. This allows users to invoke the CLI using either name:

- codelayer.rb: Added 'codelayer' symlink to humanlayer binary
- codelayer-nightly.rb: Added 'codelayer-nightly' symlink

Users will be able to use either command name interchangeably:
- humanlayer / codelayer (stable)
- humanlayer-nightly / codelayer-nightly (nightly)

Part of ENG-2327