### PR TITLE
Add codelayer-experimental cask for continuous deployment builds

### DIFF
--- a/Casks/codelayer-experimental.rb
+++ b/Casks/codelayer-experimental.rb
@@ -1,0 +1,28 @@
+cask "codelayer-experimental" do
+  version "0.1.0-experimental-20250101000000"
+  sha256 "placeholder_will_be_updated_by_ci"
+
+  url "https://github.com/humanlayer/synclayer/releases/download/experimental-#{version}/CodeLayer-Experimental-darwin-arm64.dmg",
+      verified: "github.com/humanlayer/synclayer/"
+
+  name "CodeLayer Experimental"
+  desc "Experimental build of CodeLayer - Bleeding edge features from main branch"
+  homepage "https://humanlayer.dev/"
+
+  # No conflicts - can install alongside stable and nightly
+
+  app "CodeLayer-Experimental.app"
+
+  binary "#{appdir}/CodeLayer-Experimental.app/Contents/Resources/bin/humanlayer", target: "humanlayer-experimental"
+  binary "#{appdir}/CodeLayer-Experimental.app/Contents/Resources/bin/hld", target: "hld-experimental"
+
+  zap trash: [
+    "~/Library/Application Support/CodeLayer-Experimental",
+    "~/Library/Preferences/dev.humanlayer.wui.experimental.plist",
+    "~/Library/Saved Application State/dev.humanlayer.wui.experimental.savedState",
+    "~/.humanlayer/codelayer-experimental*.json",
+    "~/.humanlayer/daemon-experimental*.db",
+    "~/.humanlayer/daemon-experimental*.sock",
+    "~/Library/Logs/dev.humanlayer.wui.experimental/",
+  ]
+end


### PR DESCRIPTION
## Summary

This PR adds a new Homebrew cask for experimental builds of CodeLayer that are automatically created from the main branch of the synclayer repository.

## Details

- **Cask name**: `codelayer-experimental`
- **App name**: CodeLayer-Experimental.app
- **Port**: 7779 (isolated from stable=7777, nightly=7778)
- **CLI commands**: `humanlayer-experimental`, `hld-experimental`
- **Database**: `~/.humanlayer/daemon-experimental.db`
- **Socket**: `~/.humanlayer/daemon-experimental.sock`

## Installation

Once merged, users will be able to install experimental builds with:

```bash
brew tap humanlayer/humanlayer
brew install --cask codelayer-experimental
```

## Side-by-side Installation

This experimental build can be installed alongside stable and nightly versions without conflicts, using completely isolated:
- Application bundles
- Configuration directories
- Database files
- Network ports
- CLI command names

## Automation

The cask will be automatically updated by GitHub Actions whenever a new experimental build is created from pushes to the main branch in the synclayer repository.