### PR TITLE
Rollback riptide-experimental to 20260121193155-experimental

### DIFF
--- a/Casks/riptide-experimental.rb
+++ b/Casks/riptide-experimental.rb
@@ -1,8 +1,8 @@
 cask "riptide-experimental" do
-  version "20260122032302-experimental"
-  sha256 "2e5eeddb70e3269821f7cfeb17fb6b6dc4667a6e8c610dfdc5c4e8fbbf7b4b8a"
+  version "20260121193155-experimental"
+  sha256 "738e1adbd64dd4c2195f06d34d027830ec60884d12c9fef3ca37f73a901b6af2"
 
-  url "https://github.com/humanlayer/homebrew-humanlayer/releases/download/riptide-experimental-20260122032302-experimental/Riptide-Experimental-darwin-arm64.dmg",
+  url "https://github.com/humanlayer/homebrew-humanlayer/releases/download/riptide-experimental-20260121193155-experimental/Riptide-Experimental-darwin-arm64.dmg",
       verified: "github.com/humanlayer/homebrew-humanlayer/"
 
   name "Riptide-Experimental"


### PR DESCRIPTION
Rolls back riptide-experimental to the version from 23 hours ago.