### PR TITLE
fix: revert riptide-beta to main branch build

### DIFF
--- a/Casks/riptide-beta.rb
+++ b/Casks/riptide-beta.rb
@@ -1,8 +1,8 @@
 cask "riptide-beta" do
-  version "20260214193223-beta"
-  sha256 "5c51062b32265a774121db3615c66bbcdcbc0ffb731764c2a4b364dc33be5662"
+  version "20260214031101-beta"
+  sha256 "2bd65e7c884e9fb7c6be6f28606239340697d99ca511df4c724ad8b91226c4ed"
 
-  url "https://github.com/humanlayer/homebrew-humanlayer/releases/download/riptide-beta-20260214193223-beta/Riptide-Beta-darwin-arm64.dmg",
+  url "https://github.com/humanlayer/homebrew-humanlayer/releases/download/riptide-beta-20260214031101-beta/Riptide-Beta-darwin-arm64.dmg",
       verified: "github.com/humanlayer/homebrew-humanlayer/"
 
   name "Riptide-Beta"


### PR DESCRIPTION
## Summary

- Reverts commit 49c2e41 which updated `riptide-beta` to a build from the `app-signing` feature branch
- The `app-signing` branch forked off `main` on Feb 7 and is missing **134+ commits** of feature work that landed on `main` between Feb 7-14
- This restores the cask to `20260214031101-beta`, built from `main` at `dda5b314`

## Root cause

The "Release Riptide Beta" workflow was dispatched against the `app-signing` branch (run `22022992821`), producing a build with a newer timestamp (`20260214193223`) but from much older code (SHA `4dff067a`, based on Feb 7 main). This overwrote the cask that previously pointed to a proper `main` build.

## Test plan

- [ ] Merge this PR
- [ ] Run `brew update && brew upgrade riptide-beta` and verify the correct version is installed
- [ ] Consider adding branch guards to the Release Riptide Beta workflow to prevent non-main dispatches

🤖 Generated with [Claude Code](https://claude.com/claude-code)