### PR TITLE
chore: 'verified' removed as parameter

### DIFF
--- a/Casks/humanlayer-beta.rb
+++ b/Casks/humanlayer-beta.rb
@@ -2,8 +2,7 @@ cask "humanlayer-beta" do
   version "0.171.0"
   sha256 "7cb66d87950bc28489a98690b6da43a94437b5313aeb70f32775f1a76cc0cb32"
 
-  url "https://github.com/humanlayer/homebrew-humanlayer/releases/download/riptide-beta-v0.171.0-20260905205932/Riptide-Beta-darwin-arm64.dmg",
-      verified: "github.com/humanlayer/homebrew-humanlayer/"
+  url "https://github.com/humanlayer/homebrew-humanlayer/releases/download/riptide-beta-v0.171.0-20260905205932/Riptide-Beta-darwin-arm64.dmg"
   name "HumanLayer-Beta"
   desc "Beta build of HumanLayer pointing at beta environment"
   homepage "https://humanlayer.dev/"

--- a/Casks/humanlayer-dev.rb
+++ b/Casks/humanlayer-dev.rb
@@ -2,8 +2,7 @@ cask "humanlayer-dev" do
   version "0.171.6"
   sha256 "b0fbd0f0986d4b5aae8c3f243dd007147020e83bee83631f6c5e59b5a9cd6d26"
 
-  url "https://github.com/humanlayer/homebrew-humanlayer/releases/download/riptide-dev-v0.171.6-20260906093925/Riptide-Dev-darwin-arm64.dmg",
-      verified: "github.com/humanlayer/homebrew-humanlayer/"
+  url "https://github.com/humanlayer/homebrew-humanlayer/releases/download/riptide-dev-v0.171.6-20260906093925/Riptide-Dev-darwin-arm64.dmg"
   name "HumanLayer-Dev"
   desc "Development build of HumanLayer pointing at dev environment"
   homepage "https://humanlayer.dev/"

--- a/Casks/humanlayer-electron-beta.rb
+++ b/Casks/humanlayer-electron-beta.rb
@@ -4,8 +4,7 @@ cask "humanlayer-electron-beta" do
   version "0.171.0"
   sha256 "ab03cd716d517afd3660bc266a3ee12e307b106abd8b71d58df373f55bb747a8"
 
-  url "https://github.com/humanlayer/homebrew-humanlayer/releases/download/humanlayer-electron-beta-v0.171.0-20260905205932/HumanLayerElectronBeta-0.171.0-arm64.dmg",
-      verified: "github.com/humanlayer/homebrew-humanlayer/"
+  url "https://github.com/humanlayer/homebrew-humanlayer/releases/download/humanlayer-electron-beta-v0.171.0-20260905205932/HumanLayerElectronBeta-0.171.0-arm64.dmg"
   name "HumanLayerElectronBeta"
   desc "Beta Electron build of HumanLayer pointing at the beta environment"
   homepage "https://humanlayer.dev/"

--- a/Casks/humanlayer-electron-dev.rb
+++ b/Casks/humanlayer-electron-dev.rb
@@ -4,8 +4,7 @@ cask "humanlayer-electron-dev" do
   version "0.171.6"
   sha256 "2a037813d04d0c9a0c80f20d7cb313fac3a88be2b657d905982f565fcc6ef076"
 
-  url "https://github.com/humanlayer/homebrew-humanlayer/releases/download/humanlayer-electron-dev-v0.171.6-20260906093924/HumanLayerElectronDev-0.171.6-arm64.dmg",
-      verified: "github.com/humanlayer/homebrew-humanlayer/"
+  url "https://github.com/humanlayer/homebrew-humanlayer/releases/download/humanlayer-electron-dev-v0.171.6-20260906093924/HumanLayerElectronDev-0.171.6-arm64.dmg"
   name "HumanLayerElectronDev"
   desc "Development Electron build of HumanLayer pointing at the dev environment"
   homepage "https://humanlayer.dev/"

--- a/Casks/humanlayer-electron.rb
+++ b/Casks/humanlayer-electron.rb
@@ -4,8 +4,7 @@ cask "humanlayer-electron" do
   version "0.171.0"
   sha256 "fc2411c72d675e44ad1b8bb55800ecbd676298da1918901bf6f2d4153f361a93"
 
-  url "https://github.com/humanlayer/homebrew-humanlayer/releases/download/humanlayer-electron-v0.171.0/HumanLayerElectron-0.171.0-arm64.dmg",
-      verified: "github.com/humanlayer/homebrew-humanlayer/"
+  url "https://github.com/humanlayer/homebrew-humanlayer/releases/download/humanlayer-electron-v0.171.0/HumanLayerElectron-0.171.0-arm64.dmg"
   name "HumanLayerElectron"
   desc "Electron edition of the HumanLayer AI coding agent powered by Claude"
   homepage "https://humanlayer.dev/"

--- a/Casks/humanlayer.rb
+++ b/Casks/humanlayer.rb
@@ -2,8 +2,7 @@ cask "humanlayer" do
   version "0.171.0"
   sha256 "634650e930fc4623fe6bbfe1f65eb8ae58cbdd130f324056c3e609bd68045396"
 
-  url "https://github.com/humanlayer/homebrew-humanlayer/releases/download/riptide-v0.171.0/Riptide-darwin-arm64.dmg",
-      verified: "github.com/humanlayer/homebrew-humanlayer/"
+  url "https://github.com/humanlayer/homebrew-humanlayer/releases/download/riptide-v0.171.0/Riptide-darwin-arm64.dmg"
   name "HumanLayer"
   desc "AI coding agent powered by Claude"
   homepage "https://humanlayer.dev/"

--- a/Casks/riptide-beta.rb
+++ b/Casks/riptide-beta.rb
@@ -2,8 +2,7 @@ cask "riptide-beta" do
   version "0.171.0"
   sha256 "7cb66d87950bc28489a98690b6da43a94437b5313aeb70f32775f1a76cc0cb32"
 
-  url "https://github.com/humanlayer/homebrew-humanlayer/releases/download/riptide-beta-v0.171.0-20260905205932/Riptide-Beta-darwin-arm64.dmg",
-      verified: "github.com/humanlayer/homebrew-humanlayer/"
+  url "https://github.com/humanlayer/homebrew-humanlayer/releases/download/riptide-beta-v0.171.0-20260905205932/Riptide-Beta-darwin-arm64.dmg"
   name "Riptide-Beta"
   desc "Beta build of HumanLayer pointing at beta environment"
   homepage "https://humanlayer.dev/"

--- a/Casks/riptide-dev.rb
+++ b/Casks/riptide-dev.rb
@@ -2,8 +2,7 @@ cask "riptide-dev" do
   version "0.171.6"
   sha256 "b0fbd0f0986d4b5aae8c3f243dd007147020e83bee83631f6c5e59b5a9cd6d26"
 
-  url "https://github.com/humanlayer/homebrew-humanlayer/releases/download/riptide-dev-v0.171.6-20260906093925/Riptide-Dev-darwin-arm64.dmg",
-      verified: "github.com/humanlayer/homebrew-humanlayer/"
+  url "https://github.com/humanlayer/homebrew-humanlayer/releases/download/riptide-dev-v0.171.6-20260906093925/Riptide-Dev-darwin-arm64.dmg"
   name "Riptide-Dev"
   desc "Development build of HumanLayer pointing at dev environment"
   homepage "https://humanlayer.dev/"

--- a/Casks/riptide-electron-beta.rb
+++ b/Casks/riptide-electron-beta.rb
@@ -4,8 +4,7 @@ cask "riptide-electron-beta" do
   version "0.157.0"
   sha256 "d16d5f1543d549f84d97d2e72666df15c7e8111f03a8ba6b871d1d13ff14504a"
 
-  url "https://github.com/humanlayer/homebrew-humanlayer/releases/download/humanlayer-electron-beta-v0.157.0-20260813210102/HumanLayerElectronBeta-0.157.0-arm64.dmg",
-      verified: "github.com/humanlayer/homebrew-humanlayer/"
+  url "https://github.com/humanlayer/homebrew-humanlayer/releases/download/humanlayer-electron-beta-v0.157.0-20260813210102/HumanLayerElectronBeta-0.157.0-arm64.dmg"
   name "HumanLayerElectronBeta"
   desc "Beta Electron build of HumanLayer pointing at the beta environment"
   homepage "https://humanlayer.dev/"

--- a/Casks/riptide-electron-dev.rb
+++ b/Casks/riptide-electron-dev.rb
@@ -4,8 +4,7 @@ cask "riptide-electron-dev" do
   version "0.1.12"
   sha256 "52c9e4cba60593837ed7cfc225004b7f6570196a3458be4861ffe95dc0f2308a"
 
-  url "https://github.com/humanlayer/homebrew-humanlayer/releases/download/humanlayer-electron-dev-v0.1.12/HumanLayerElectronDev-0.1.12-arm64.dmg",
-      verified: "github.com/humanlayer/homebrew-humanlayer/"
+  url "https://github.com/humanlayer/homebrew-humanlayer/releases/download/humanlayer-electron-dev-v0.1.12/HumanLayerElectronDev-0.1.12-arm64.dmg"
   name "HumanLayerElectronDev"
   desc "Development Electron build of HumanLayer pointing at the dev environment"
   homepage "https://humanlayer.dev/"

--- a/Casks/riptide-electron.rb
+++ b/Casks/riptide-electron.rb
@@ -4,8 +4,7 @@ cask "riptide-electron" do
   version "0.157.0"
   sha256 "ee719720b5cfdde5c319a0277fcad84fa5c70f05f4f5e6a3c68e1c4f9b1606d2"
 
-  url "https://github.com/humanlayer/homebrew-humanlayer/releases/download/humanlayer-electron-v0.157.0/HumanLayerElectron-0.157.0-arm64.dmg",
-      verified: "github.com/humanlayer/homebrew-humanlayer/"
+  url "https://github.com/humanlayer/homebrew-humanlayer/releases/download/humanlayer-electron-v0.157.0/HumanLayerElectron-0.157.0-arm64.dmg"
   name "HumanLayerElectron"
   desc "Electron edition of the HumanLayer AI coding agent powered by Claude"
   homepage "https://humanlayer.dev/"

--- a/Casks/riptide.rb
+++ b/Casks/riptide.rb
@@ -2,8 +2,7 @@ cask "riptide" do
   version "0.171.0"
   sha256 "634650e930fc4623fe6bbfe1f65eb8ae58cbdd130f324056c3e609bd68045396"
 
-  url "https://github.com/humanlayer/homebrew-humanlayer/releases/download/riptide-v0.171.0/Riptide-darwin-arm64.dmg",
-      verified: "github.com/humanlayer/homebrew-humanlayer/"
+  url "https://github.com/humanlayer/homebrew-humanlayer/releases/download/riptide-v0.171.0/Riptide-darwin-arm64.dmg"
   name "Riptide"
   desc "AI coding agent powered by Claude"
   homepage "https://humanlayer.dev/"


### PR DESCRIPTION
Fixes #8 

Removed 'verified' parameter from all the url within .rb files in Casks folder.